### PR TITLE
Improve robustness of stock analysis pipeline

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -30,13 +30,23 @@ def get_market_insights():
     # Get data for key market indicators
     market_data = get_nifty50_data(NIFTY50_SYMBOLS[:5])  # Using top 5 stocks as sample
     analysis = format_stock_analysis(market_data)
-    
+
+    if not analysis:
+        return {
+            'sentiment': 'Unknown',
+            'top_movers': 0,
+            'buy_signals': 0,
+            'sell_signals': 0,
+        }
+
+    avg_health = sum(stock.get('health_score', 0) for stock in analysis) / len(analysis)
+
     # Calculate market insights
     insights = {
-        'sentiment': 'Positive' if sum(stock['health_score'] for stock in analysis) / len(analysis) > 50 else 'Negative',
+        'sentiment': 'Positive' if avg_health > 50 else 'Negative',
         'top_movers': len([stock for stock in analysis if abs(stock.get('day_change', 0)) > 2]),  # Stocks moving >2%
-        'buy_signals': len([stock for stock in analysis if stock['action'] == 'Buy']),
-        'sell_signals': len([stock for stock in analysis if stock['action'] == 'Sell'])
+        'buy_signals': len([stock for stock in analysis if stock.get('action') == 'Buy']),
+        'sell_signals': len([stock for stock in analysis if stock.get('action') == 'Sell'])
     }
     return insights
 


### PR DESCRIPTION
## Summary
- improve the parallel downloader by iterating futures as they complete and logging fetch failures while keeping progress updates accurate
- add resilient numeric parsing in the stock formatter so missing or invalid indicator values no longer break output and use computed support/resistance/volatility data when available
- prevent the web dashboard from crashing when no analysis data is returned by short-circuiting the insight aggregation

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c87966c1f0832bbc0bbf3e66385b2e